### PR TITLE
ci: remove references to prisma

### DIFF
--- a/.github/workflows/preview-deploy-vercel.yaml
+++ b/.github/workflows/preview-deploy-vercel.yaml
@@ -49,10 +49,6 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         run: pnpm install
-      - name: Generate prisma client
-        run: pnpm run prisma:generate
-      - name: Run production migration
-        run: pnpm dlx prisma migrate deploy
       - name: Ensure playwright has the latest browser binaries
         run: pnpx playwright install --with-deps && npx playwright install --with-deps
       - name: Ensure project is formatted and linted

--- a/.github/workflows/prod-deploy-vercel.yaml
+++ b/.github/workflows/prod-deploy-vercel.yaml
@@ -46,10 +46,6 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         run: pnpm install
-      - name: Generate prisma client
-        run: pnpm run prisma:generate
-      - name: Run production migration
-        run: pnpm run migrate:prod:vercel
       - name: Ensure playwright has the latest browser binaries
         run: pnpx playwright install --with-deps && npx playwright install --with-deps
       - name: Ensure project is formatted and linted


### PR DESCRIPTION
### TL;DR
Removed Prisma client generation and migration steps from Vercel deployment workflows.

### What changed?
- Removed `prisma:generate` step from both preview and production deployment workflows
- Removed `prisma migrate deploy` step from preview deployment workflow
- Removed `migrate:prod:vercel` step from production deployment workflow

### How to test?
1. Create a new pull request
2. Verify that the preview deployment workflow completes successfully without Prisma steps
3. Merge to main and verify that the production deployment workflow completes successfully

### Why make this change?
Prisma client generation and database migrations are now handled directly by Vercel during the build process, making these workflow steps redundant. This change streamlines the deployment process and reduces potential points of failure.