### PR TITLE
build: removed the basicssl plugin

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,9 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { enhancedImages } from '@sveltejs/enhanced-img';
 import { defineConfig } from 'vitest/config';
-import basicSsl from '@vitejs/plugin-basic-ssl';
 
 export default defineConfig({
-  plugins: [
-    enhancedImages(),
-    sveltekit(),
-    basicSsl({
-      name: 'localhost'
-    })
-  ],
+  plugins: [enhancedImages(), sveltekit()],
   test: {
     include: ['src/**/*.{test,spec}.{js,ts}']
   }


### PR DESCRIPTION
### TL;DR
Removed basic SSL plugin from Vite configuration

### What changed?
Removed the `@vitejs/plugin-basic-ssl` plugin and its configuration from the Vite setup, while maintaining the enhanced images and SvelteKit plugins.

### How to test?
1. Start the development server
2. Verify that the application runs correctly without SSL
3. Ensure that enhanced images and SvelteKit functionality continue to work as expected

### Why make this change?
The basic SSL plugin was likely unnecessary for local development, and removing it simplifies the configuration. If SSL is needed, it can be handled through other means such as a reverse proxy or production environment configuration.