### PR TITLE
ci: secure the new vercel deploy actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/preview-deploy-vercel.yaml
+++ b/.github/workflows/preview-deploy-vercel.yaml
@@ -19,20 +19,28 @@ env:
   VITE_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
   VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
   VITE_FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}
+permissions:
+  contents: read
+
 jobs:
   Build-and-Test:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+
       - name: Checkout the Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: '22'
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: 9
           run_install: false
@@ -40,7 +48,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -60,7 +68,7 @@ jobs:
       - name: Test
         run: pnpm run test
       - name: Setup GPG Keys
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
         with:
           git_user_signingkey: true
           git_commit_gpgsign: true
@@ -79,8 +87,13 @@ jobs:
     needs: Build-and-Test
     if: needs.Build-and-Test.result == 'success'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+
       - name: Checkout the Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Decide Deployment Environment
         id: deployment_environment
         run: |
@@ -90,11 +103,11 @@ jobs:
             echo echo "PROJECT_ENVIRONMENT=preview" >> $GITHUB_ENV
           fi
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: '22'
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: 9
           run_install: false
@@ -102,7 +115,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}

--- a/.github/workflows/prod-deploy-vercel.yaml
+++ b/.github/workflows/prod-deploy-vercel.yaml
@@ -16,20 +16,28 @@ env:
   VITE_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
   VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
   VITE_FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}
+permissions:
+  contents: read
+
 jobs:
   Build-and-Test:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+
       - name: Checkout the Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: '22'
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: 9
           run_install: false
@@ -37,7 +45,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -57,7 +65,7 @@ jobs:
       - name: Test
         run: pnpm run test
       - name: Setup GPG Keys
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
         with:
           git_user_signingkey: true
           git_commit_gpgsign: true
@@ -77,8 +85,13 @@ jobs:
     needs: Build-and-Test
     if: needs.Build-and-Test.result == 'success'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+
       - name: Checkout the Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Decide Deployment Environment
         id: deployment_environment
         run: |
@@ -88,11 +101,11 @@ jobs:
             echo echo "PROJECT_ENVIRONMENT=preview" >> $GITHUB_ENV
           fi
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: '22'
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: 9
           run_install: false
@@ -100,7 +113,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}


### PR DESCRIPTION
### TL;DR
Added GitHub Actions to Dependabot monitoring and implemented security hardening for CI/CD workflows.

### What changed?
- Configured Dependabot to monitor GitHub Actions dependencies
- Added StepSecurity's harden-runner to CI/CD workflows
- Pinned all GitHub Action versions to specific commit hashes
- Added explicit read-only permissions to workflow files
- Updated GitHub Actions to their latest secure versions

### How to test?
1. Verify Dependabot creates PRs for GitHub Actions updates
2. Check that CI/CD workflows complete successfully
3. Confirm the harden-runner is auditing network egress
4. Validate that workflows maintain read-only access to repository contents

### Why make this change?
To enhance security by:
- Keeping GitHub Actions dependencies up-to-date automatically
- Preventing supply chain attacks through pinned action versions
- Monitoring and controlling workflow network access
- Implementing the principle of least privilege for workflow permissions