### PR TITLE
build: update the browserslist configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.9.9",
   "packageManager": "pnpm@9.14.4",
   "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not dead",
-    "not ie 11"
+    "> 0.5%",
+    "last 10 versions",
+    "node > 22",
+    "not dead"
   ],
   "scripts": {
     "dev": "vite dev --host 0.0.0.0",
@@ -17,7 +17,8 @@
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write .",
-    "emulate": "firebase emulators:start"
+    "emulate": "firebase emulators:start",
+    "supported_browsers": "echo \"export default $(browserslist-useragent-regexp --allowHigherVersions);\" > src/lib/utils/supportedBrowsers.ts"
   },
   "devDependencies": {
     "@eslint/js": "9.8.0",
@@ -31,6 +32,7 @@
     "@types/node": "18.19.42",
     "@vitejs/plugin-basic-ssl": "^1.2.0",
     "autoprefixer": "10.4.20",
+    "browserslist-useragent-regexp": "^4.1.3",
     "daisyui": "4.12.10",
     "eslint": "9.8.0",
     "eslint-config-prettier": "9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.4.40)
+      browserslist-useragent-regexp:
+        specifier: ^4.1.3
+        version: 4.1.3(browserslist@4.24.2)
       daisyui:
         specifier: 4.12.10
         version: 4.12.10(postcss@8.4.40)
@@ -1480,6 +1483,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  argue-cli@2.1.0:
+    resolution: {integrity: sha512-dgojXfc4SiqmNwe38PnbT3zJasrz7g62dLAPD+VFT5RJb8W7LGRqw2IFd2ES+plnhsp4HYNJmFqMU1tCThdCww==}
+    engines: {node: '>=14.0.0'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -1596,6 +1603,13 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browserslist-useragent-regexp@4.1.3:
+    resolution: {integrity: sha512-+KteEIVlrE2eJOmtteWhcs3wYKjbFd9fVPzPlj4VGggKMyf9orf+zjmlNt91ekInZ2zqox5ArEZD/tKXDj0v9Q==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>=4.0.0'
 
   browserslist@4.24.2:
     resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
@@ -2036,6 +2050,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  easy-table@1.2.0:
+    resolution: {integrity: sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -3956,6 +3973,10 @@ packages:
   redeyed@2.1.1:
     resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
 
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
+
   registry-auth-token@5.0.3:
     resolution: {integrity: sha512-1bpc9IyC+e+CNFRaWyn77tk4xGG4PPUyfakSmA6F6cvUDjrm58dfyJ3II+9yb10EDkHoy1LaPSmHaWLOH3m6HA==}
     engines: {node: '>=14'}
@@ -4521,6 +4542,10 @@ packages:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ua-regexes-lite@1.2.1:
+    resolution: {integrity: sha512-ling4WX4ZtxXjmSMHzuI8PGos2brw/6gG3YuVWn5RunHoQjeCokpFeMe/ti+R8E7kOTLE2FqBG4bMdFQLFwcJQ==}
+    engines: {node: '>=14'}
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
@@ -6387,6 +6412,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  argue-cli@2.1.0: {}
+
   aria-query@5.3.2: {}
 
   array-flatten@1.1.1: {}
@@ -6505,6 +6532,15 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browserslist-useragent-regexp@4.1.3(browserslist@4.24.2):
+    dependencies:
+      argue-cli: 2.1.0
+      browserslist: 4.24.2
+      easy-table: 1.2.0
+      picocolors: 1.1.1
+      regexp-tree: 0.1.27
+      ua-regexes-lite: 1.2.1
 
   browserslist@4.24.2:
     dependencies:
@@ -6912,6 +6948,12 @@ snapshots:
       stream-shift: 1.0.3
 
   eastasianwidth@0.2.0: {}
+
+  easy-table@1.2.0:
+    dependencies:
+      ansi-regex: 5.0.1
+    optionalDependencies:
+      wcwidth: 1.0.1
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -9069,6 +9111,8 @@ snapshots:
     dependencies:
       esprima: 4.0.1
 
+  regexp-tree@0.1.27: {}
+
   registry-auth-token@5.0.3:
     dependencies:
       '@pnpm/npm-conf': 2.3.1
@@ -9735,6 +9779,8 @@ snapshots:
   typescript@4.9.5: {}
 
   typescript@5.5.4: {}
+
+  ua-regexes-lite@1.2.1: {}
 
   uc.micro@2.1.0: {}
 


### PR DESCRIPTION
### TL;DR
Updated browser compatibility targets and added browser detection capability

### What changed?
- Modified browserslist configuration to target browsers with >0.5% usage (previously >1%)
- Extended browser version support from 2 to 10 versions
- Added Node.js v22 support requirement
- Added new `supported_browsers` npm script to generate browser detection utilities
- Installed `browserslist-useragent-regexp` dependency

### How to test?
1. Run `pnpm install` to update dependencies
2. Execute `pnpm supported_browsers` to generate browser detection utilities
3. Verify the application works in browsers that meet the new compatibility criteria
4. Test with Node.js v22 to ensure compatibility

### Why make this change?
To broaden browser support and provide better compatibility with older browser versions while maintaining modern features. The addition of browser detection capabilities will help ensure users are using supported browsers and receive appropriate notifications if they aren't.