### PR TITLE
test: add functioning tests for Title Component

### DIFF
--- a/src/lib/components/Title.spec.ts
+++ b/src/lib/components/Title.spec.ts
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/svelte/svelte5';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it } from 'vitest';
+import Title from './Title.svelte'; // Adjust the path as needed
+
+describe('Title', () => {
+  it('renders the title correctly', () => {
+    // Render the component with a test title
+    const title = 'Test Title';
+    render(Title, { props: { title } });
+
+    // Check if the title is rendered
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveTextContent(title);
+  });
+
+  it('applies the correct styles to the title', () => {
+    // Render the component
+    const title = 'Styled Title';
+    render(Title, { props: { title } });
+
+    // Check styles of the heading
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveClass('font-serif text-xl font-bold md:text-3xl lg:text-5xl');
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,10 @@
+// Extend Jest matchers for better DOM assertions
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/svelte/svelte5';
+
+afterEach(() => {
+  cleanup();
+});
+
+// Add any custom global setup for tests here
+console.info('Test environment setup complete');


### PR DESCRIPTION
### TL;DR
Added unit tests for the Title component and test setup configuration.

### What changed?
- Created unit tests for the Title component to verify rendering and styling
- Added a global test setup file with cleanup functionality
- Implemented tests to verify heading level, content, and Tailwind CSS classes

### How to test?
1. Run the test suite using `npm test` or `vitest`
2. Verify that both Title component tests pass:
   - Title content rendering test
   - Title styling verification test
3. Confirm the test setup file is properly cleaning up after each test

### Why make this change?
To ensure the Title component maintains its expected functionality and styling through automated testing, reducing the likelihood of regressions and improving code reliability. The test setup configuration provides a consistent testing environment across all test files.