### PR TITLE
build: upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
     "@sentry/tracing": "7.114.0",
     "@sveltejs/adapter-vercel": "5.6.1",
     "firebase": "11.0.2",
-    "playwright": "^1.49.0"
+    "playwright": "^1.50.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: 11.0.2
         version: 11.0.2
       playwright:
-        specifier: ^1.49.0
+        specifier: ^1.50.1
         version: 1.50.1
     devDependencies:
       '@eslint/js':


### PR DESCRIPTION
### TL;DR
Upgraded Playwright from v1.49.0 to v1.50.1

### What changed?
Updated the Playwright dependency version in both package.json and pnpm-lock.yaml files to the latest version 1.50.1

### How to test?
1. Pull the latest changes
2. Run `pnpm install`
3. Execute existing Playwright tests to ensure they run successfully with the new version

### Why make this change?
Keeping Playwright up to date ensures we have access to the latest features, bug fixes, and security updates. Version 1.50.1 includes various improvements and fixes that benefit our testing infrastructure.