### PR TITLE
docs: fix badge errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ SPDX-License-Identifier: MIT
 
 # Just fucking Google It
 
-[![Build Status](https://github.com/your-username/justfuckinggoogleit/actions/workflows/ci.yml/badge.svg)](https://github.com/your-username/justfuckinggoogleit/actions)
+[![Build Status](https://github.com/AliSajid/justfuckinggoogleit/actions/workflows/ci.yml/badge.svg)](https://github.com/AliSajid/jfgi/actions)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Ffuckinggoogleit.com)](https://fuckinggoogleit.com)
-[![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](./CONTRIBUTING.md)
-[![Issues](https://img.shields.io/github/issues/your-username/justfuckinggoogleit)](https://github.com/your-username/justfuckinggoogleit/issues)
+[![Contributions Welcome](https://img.shields.io/badge/Contributions?-Yes!-brightgreen.svg)](./CONTRIBUTING.md)
+[![Issues](https://img.shields.io/github/issues/AliSajid/justfuckinggoogleit)](https://github.com/AliSajid/jfgi/issues)
 
 Have you ever been baffled by someone's inability to use Google? Do you wish there was a way to nudge them in the right direction without resorting to sarcasm? Well, now there is! **Just fucking Google It** is a simple website for redirecting clueless questions into enlightening Google searches.
 


### PR DESCRIPTION
### TL;DR

Updated repository badges with correct username and links

### What changed?

- Updated build status badge to point to `AliSajid/justfuckinggoogleit`
- Modified contributions badge text to "Contributions? Yes!"
- Updated issues badge to reference `AliSajid/jfgi`
- Fixed repository links in badge URLs

### How to test?

1. Click each badge in the README
2. Verify they lead to the correct repository pages
3. Confirm the build status badge shows current workflow status
4. Ensure the issues badge displays the correct count

### Why make this change?

The repository badges were using placeholder URLs with "your-username", which needed to be updated to the actual repository owner. This ensures proper tracking of build status, issues, and contributions while maintaining accurate repository links.